### PR TITLE
Akka to pekko

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Service | Status | Description
 ------- | ------ | -----------
 Gitter            | [![Join the chat at https://gitter.im/exini/dicom-streams](https://badges.gitter.im/exini/dicom-streams.svg)](https://gitter.im/exini/dicom-streams?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) | Chatroom
 
-The purpose of this project is to create a streaming API for reading and processing DICOM data using [akka-streams](http://doc.akka.io/docs/akka/current/scala/stream/index.html). 
+The purpose of this project is to create a streaming API for reading and processing DICOM data using [pekko-streams](https://pekko.apache.org/docs/pekko/current/stream/index.html). 
 
 Advantages of streaming DICOM data include better control over resource allocation such as memory via strict bounds on
 DICOM data chunk size and network utilization using back-pressure as specified in the
@@ -12,7 +12,7 @@ DICOM data chunk size and network utilization using back-pressure as specified i
 
 The library is split in two projects. The `data` project defines data structures and common functionality with minimal
 dependencies and offers synchronous parsing of (possibly chunked) binary data. The `streams` project provides 
-functionality for streaming DICOM data and pulls in Akka as a required dependency.
+functionality for streaming DICOM data and pulls in [Pekko](https://pekko.apache.org) as a required dependency.
 
 The logic of parsing and handling DICOM data is inspired by [dcm4che](https://github.com/dcm4che/dcm4che)
 which provides a far more complete (albeit blocking and synchronous) implementation of the DICOM standard.
@@ -37,8 +37,8 @@ libraryDependencies += "com.exini" %% "dicom-data" % "x.y.z"
 ### Data Model
 
 Streaming binary DICOM data may originate from many different sources such as files, a HTTP POST request, or a read from
-a database. Akka Streams provide a multitude of connectors for streaming binary data. Streaming data arrives in chunks. 
-In the Akka Stream nomenclature, chunks originate from _sources_, they are processed in _flows_ and folded into a 
+a database. Pekko Streams provide a multitude of connectors for streaming binary data. Streaming data arrives in chunks. 
+In the Pekko Stream nomenclature, chunks originate from _sources_, they are processed in _flows_ and folded into a 
 non-streaming plain objects using _sinks_. 
 
 This library provides flows for parsing binary DICOM data into DICOM parts (represented by the `DicomPart` interface) - 

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val coverageSettings = Seq(
   coverageExcludedPackages := ".*\\.BuildInfo.*;.*\\.Tag.*;.*\\.UID.*;.*\\.TagToKeyword.*;.*\\.TagToVR.*;.*\\.TagToVM.*\\.UIDToName.*"
 )
 
-lazy val akkaVersion = "2.8.5"
+lazy val pekkoVersion = "1.0.2"
 
 lazy val dataLib = project
   .in(file("data"))
@@ -72,7 +72,7 @@ lazy val dataLib = project
   .settings(managedSourcesSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "org.slf4j"      % "slf4j-simple" % "2.0.9",
+      "org.slf4j"      % "slf4j-simple" % "2.0.12",
       "org.scalatest" %% "scalatest"    % "3.2.17" % "test"
     )
   )
@@ -82,9 +82,9 @@ lazy val streamsLib = project
   .settings(name := "dicom-streams")
   .settings(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-stream"         % akkaVersion,
-      "com.typesafe.akka" %% "akka-slf4j"          % akkaVersion,
-      "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % "test"
+      "org.apache.pekko" %% "pekko-stream"         % pekkoVersion,
+      "org.apache.pekko" %% "pekko-slf4j"          % pekkoVersion,
+      "org.apache.pekko" %% "pekko-stream-testkit" % pekkoVersion % "test"
     )
   )
   .dependsOn(dataLib % "test->test;compile->compile")

--- a/data/src/main/scala/com/exini/dicom/data/ByteParser.scala
+++ b/data/src/main/scala/com/exini/dicom/data/ByteParser.scala
@@ -23,7 +23,7 @@ import scala.util.control.{ NoStackTrace, NonFatal }
 
 /**
   * This class is borrowed (with modifications) from the
-  * <a href="https://github.com/akka/akka/blob/master/akka-stream/src/main/scala/akka/stream/impl/io/ByteStringParser.scala">AKKA internal API</a>.
+  * <a href="https://github.com/apache/incubator-pekko/blob/main/stream/src/main/scala/org/apache/pekko/stream/impl/io/ByteStringParser.scala">Pekko internal API</a>.
   * It provides a stateful parser from byte chunks to objects of type <code>T</code>.
   *
   * @param target target

--- a/streams/src/main/scala/com/exini/dicom/streams/ByteParserFlow.scala
+++ b/streams/src/main/scala/com/exini/dicom/streams/ByteParserFlow.scala
@@ -1,10 +1,10 @@
 package com.exini.dicom.streams
 
-import akka.stream._
-import akka.stream.stage._
-import akka.util.ByteString
 import com.exini.dicom.data.ByteParser
 import com.exini.dicom.data.ByteParser.{ ByteParserTarget, ByteReader, ParseStep }
+import org.apache.pekko.stream._
+import org.apache.pekko.stream.stage._
+import org.apache.pekko.util.ByteString
 
 abstract class ByteParserFlow[T] extends GraphStage[FlowShape[ByteString, T]] {
 

--- a/streams/src/main/scala/com/exini/dicom/streams/CollectFlow.scala
+++ b/streams/src/main/scala/com/exini/dicom/streams/CollectFlow.scala
@@ -16,11 +16,11 @@
 
 package com.exini.dicom.streams
 
-import akka.stream.Attributes
-import akka.stream.stage.GraphStageLogic
 import com.exini.dicom.data.DicomElements._
 import com.exini.dicom.data.DicomParts._
 import com.exini.dicom.data.{ Elements, _ }
+import org.apache.pekko.stream.Attributes
+import org.apache.pekko.stream.stage.GraphStageLogic
 
 object CollectFlow {
 

--- a/streams/src/main/scala/com/exini/dicom/streams/DicomFlow.scala
+++ b/streams/src/main/scala/com/exini/dicom/streams/DicomFlow.scala
@@ -16,11 +16,11 @@
 
 package com.exini.dicom.streams
 
-import akka.stream.stage._
-import akka.stream.{ Attributes, FlowShape, Inlet, Outlet }
 import com.exini.dicom.data.DicomParts._
 import com.exini.dicom.data.TagPath._
 import com.exini.dicom.data.{ Tag, TagPath, emptyBytes, isGroupLength }
+import org.apache.pekko.stream.stage._
+import org.apache.pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
 
 /**
   * This class defines events for modular construction of DICOM flows. Events correspond to the DICOM parts commonly

--- a/streams/src/main/scala/com/exini/dicom/streams/ElementSink.scala
+++ b/streams/src/main/scala/com/exini/dicom/streams/ElementSink.scala
@@ -16,9 +16,9 @@
 
 package com.exini.dicom.streams
 
-import akka.stream.scaladsl.{ Flow, Keep, Sink }
 import com.exini.dicom.data.DicomElements.Element
 import com.exini.dicom.data.{ Elements, ElementsBuilder }
+import org.apache.pekko.stream.scaladsl.{ Flow, Keep, Sink }
 
 import scala.concurrent.{ ExecutionContext, Future }
 

--- a/streams/src/main/scala/com/exini/dicom/streams/ModifyFlow.scala
+++ b/streams/src/main/scala/com/exini/dicom/streams/ModifyFlow.scala
@@ -16,12 +16,12 @@
 
 package com.exini.dicom.streams
 
-import akka.stream.Attributes
-import akka.stream.stage.GraphStageLogic
-import akka.util.ByteString
 import com.exini.dicom.data.DicomParts._
 import com.exini.dicom.data.TagPath.{ EmptyTagPath, TagPathTag }
 import com.exini.dicom.data.{ Lookup, TagPath, VR, isFileMetaInformation, _ }
+import org.apache.pekko.stream.Attributes
+import org.apache.pekko.stream.stage.GraphStageLogic
+import org.apache.pekko.util.ByteString
 
 object ModifyFlow {
 

--- a/streams/src/main/scala/com/exini/dicom/streams/streams.scala
+++ b/streams/src/main/scala/com/exini/dicom/streams/streams.scala
@@ -16,12 +16,12 @@
 
 package com.exini.dicom
 
-import akka.NotUsed
-import akka.stream.Materializer
-import akka.stream.scaladsl.{ Flow, Source }
-import akka.util.ByteString
 import com.exini.dicom.data.DicomParts.DicomPart
 import com.exini.dicom.data._
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{ Flow, Source }
+import org.apache.pekko.util.ByteString
 
 import scala.concurrent.duration.{ DurationInt, FiniteDuration }
 import scala.concurrent.{ Await, ExecutionContext, Future }

--- a/streams/src/test/scala/com/exini/dicom/streams/Chunker.scala
+++ b/streams/src/test/scala/com/exini/dicom/streams/Chunker.scala
@@ -1,8 +1,8 @@
 package com.exini.dicom.streams
 
-import akka.stream._
-import akka.stream.stage._
-import akka.util.ByteString
+import org.apache.pekko.stream._
+import org.apache.pekko.stream.stage._
+import org.apache.pekko.util.ByteString
 
 class Chunker(val chunkSize: Int) extends GraphStage[FlowShape[ByteString, ByteString]] {
   val in: Inlet[ByteString]                             = Inlet[ByteString]("Chunker.in")

--- a/streams/src/test/scala/com/exini/dicom/streams/CollectFlowTest.scala
+++ b/streams/src/test/scala/com/exini/dicom/streams/CollectFlowTest.scala
@@ -1,16 +1,15 @@
 package com.exini.dicom.streams
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
-import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.TestKit
-import akka.util.ByteString
 import com.exini.dicom.data.DicomParts.ElementsPart
 import com.exini.dicom.data.TestData._
 import com.exini.dicom.data._
 import com.exini.dicom.streams.CollectFlow._
 import com.exini.dicom.streams.ParseFlow.parseFlow
-import com.exini.dicom.streams.StreamTestUtils._
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.stream.testkit.scaladsl.TestSink
+import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.util.ByteString
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -23,6 +22,8 @@ class CollectFlowTest
     with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll {
+
+  import StreamTestUtils._
 
   implicit val ec: ExecutionContextExecutor = system.dispatcher
 

--- a/streams/src/test/scala/com/exini/dicom/streams/DicomFlowTest.scala
+++ b/streams/src/test/scala/com/exini/dicom/streams/DicomFlowTest.scala
@@ -1,14 +1,14 @@
 package com.exini.dicom.streams
 
-import akka.actor.ActorSystem
-import akka.stream.Attributes
-import akka.stream.scaladsl.{ FileIO, Flow, Sink, Source }
-import akka.stream.stage.GraphStageLogic
-import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.TestKit
 import com.exini.dicom.data.TagPath.EmptyTagPath
 import com.exini.dicom.data._
 import com.exini.dicom.streams.ParseFlow.parseFlow
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Attributes
+import org.apache.pekko.stream.scaladsl.{ FileIO, Flow, Sink, Source }
+import org.apache.pekko.stream.stage.GraphStageLogic
+import org.apache.pekko.stream.testkit.scaladsl.TestSink
+import org.apache.pekko.testkit.TestKit
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike

--- a/streams/src/test/scala/com/exini/dicom/streams/DicomFlowsTest.scala
+++ b/streams/src/test/scala/com/exini/dicom/streams/DicomFlowsTest.scala
@@ -1,10 +1,5 @@
 package com.exini.dicom.streams
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.{ FileIO, Sink, Source }
-import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.TestKit
-import akka.util.ByteString
 import com.exini.dicom.data.DicomElements.ValueElement
 import com.exini.dicom.data.DicomParts.MetaPart
 import com.exini.dicom.data.TestData._
@@ -12,7 +7,11 @@ import com.exini.dicom.data._
 import com.exini.dicom.streams.DicomFlows._
 import com.exini.dicom.streams.ModifyFlow._
 import com.exini.dicom.streams.ParseFlow._
-import com.exini.dicom.streams.StreamTestUtils._
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.{ FileIO, Sink, Source }
+import org.apache.pekko.stream.testkit.scaladsl.TestSink
+import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.util.ByteString
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -27,6 +26,8 @@ class DicomFlowsTest
     with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll {
+
+  import StreamTestUtils._
 
   implicit val ec: ExecutionContextExecutor = system.dispatcher
 

--- a/streams/src/test/scala/com/exini/dicom/streams/ElementFlowsTest.scala
+++ b/streams/src/test/scala/com/exini/dicom/streams/ElementFlowsTest.scala
@@ -1,15 +1,14 @@
 package com.exini.dicom.streams
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
-import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.TestKit
 import com.exini.dicom.data.DicomElements._
 import com.exini.dicom.data.TagPath.EmptyTagPath
 import com.exini.dicom.data.TestData._
 import com.exini.dicom.data._
 import com.exini.dicom.streams.ElementFlows._
-import com.exini.dicom.streams.StreamTestUtils._
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.stream.testkit.scaladsl.TestSink
+import org.apache.pekko.testkit.TestKit
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -22,6 +21,8 @@ class ElementFlowsTest
     with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll {
+
+  import StreamTestUtils._
 
   implicit val ec: ExecutionContextExecutor = system.dispatcher
 

--- a/streams/src/test/scala/com/exini/dicom/streams/ElementSinkTest.scala
+++ b/streams/src/test/scala/com/exini/dicom/streams/ElementSinkTest.scala
@@ -1,14 +1,14 @@
 package com.exini.dicom.streams
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.{ FileIO, Source }
-import akka.testkit.TestKit
 import com.exini.dicom.data.DicomElements._
 import com.exini.dicom.data.TestData._
 import com.exini.dicom.data._
 import com.exini.dicom.streams.ElementFlows.elementFlow
 import com.exini.dicom.streams.ElementSink.elementSink
 import com.exini.dicom.streams.ParseFlow.parseFlow
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.{ FileIO, Source }
+import org.apache.pekko.testkit.TestKit
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures._

--- a/streams/src/test/scala/com/exini/dicom/streams/ModifyFlowTest.scala
+++ b/streams/src/test/scala/com/exini/dicom/streams/ModifyFlowTest.scala
@@ -1,10 +1,10 @@
 package com.exini.dicom.streams
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
-import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.TestKit
 import com.exini.dicom.data._
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.stream.testkit.scaladsl.TestSink
+import org.apache.pekko.testkit.TestKit
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers

--- a/streams/src/test/scala/com/exini/dicom/streams/ParseFlowTest.scala
+++ b/streams/src/test/scala/com/exini/dicom/streams/ParseFlowTest.scala
@@ -1,12 +1,12 @@
 package com.exini.dicom.streams
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
-import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.TestKit
 import com.exini.dicom.data.Compression.compress
 import com.exini.dicom.data.DicomElements.ValueElement
 import com.exini.dicom.data._
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.stream.testkit.scaladsl.TestSink
+import org.apache.pekko.testkit.TestKit
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers

--- a/streams/src/test/scala/com/exini/dicom/streams/StreamTestUtils.scala
+++ b/streams/src/test/scala/com/exini/dicom/streams/StreamTestUtils.scala
@@ -1,9 +1,9 @@
 package com.exini.dicom.streams
 
-import akka.stream.testkit.TestSubscriber
 import com.exini.dicom.data.DicomElements._
 import com.exini.dicom.data.DicomParts._
 import com.exini.dicom.data._
+import org.apache.pekko.stream.testkit.TestSubscriber
 
 object StreamTestUtils {
 


### PR DESCRIPTION
The only code differences is that .statefulMapConcat is deprecated in the latest version of Pekko in favor of .statefulMap, in combination with .mapConcat where necessary - so I made this change