### PR TITLE
Fixed bug where dicom part markers which always were little endian (a…

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,0 +1,6 @@
+# Dicom Streams RELEASE NOTES
+
+## Release 5.0.4
+
+- Fixed bug where switching to indeterminate length sequences and items in big endian files led to inserted 
+  delimitations with the wrong endianess (little endian)

--- a/streams/src/main/scala/com/exini/dicom/streams/CollectFlow.scala
+++ b/streams/src/main/scala/com/exini/dicom/streams/CollectFlow.scala
@@ -119,9 +119,9 @@ object CollectFlow {
                   throw new DicomStreamException("Error collecting elements: max buffer size exceeded")
 
                 part match {
-                  case ValueChunkMarker               =>
-                  case SequenceDelimitationPartMarker =>
-                  case ItemDelimitationPartMarker     =>
+                  case _: ValueChunkMarker               =>
+                  case _: SequenceDelimitationPartMarker =>
+                  case _: ItemDelimitationPartMarker     =>
                   case _ =>
                     buffer = buffer :+ part
                     currentBufferSize = currentBufferSize + part.bytes.length
@@ -163,12 +163,12 @@ object CollectFlow {
                   case item: ItemPart =>
                     maybeAdd(ItemElement(item.length, item.bigEndian))
                     Nil
-                  case ItemDelimitationPartMarker =>
+                  case _: ItemDelimitationPartMarker =>
                     Nil
                   case itemDelimitation: ItemDelimitationPart =>
                     maybeAdd(ItemDelimitationElement(itemDelimitation.bigEndian))
                     Nil
-                  case SequenceDelimitationPartMarker =>
+                  case _: SequenceDelimitationPartMarker =>
                     Nil
                   case sequenceDelimitation: SequenceDelimitationPart =>
                     maybeAdd(SequenceDelimitationElement(sequenceDelimitation.bigEndian))

--- a/streams/src/main/scala/com/exini/dicom/streams/DicomFlow.scala
+++ b/streams/src/main/scala/com/exini/dicom/streams/DicomFlow.scala
@@ -245,7 +245,8 @@ trait GuaranteedValueEvent[Out] extends DicomFlow[Out] with InFragments[Out] {
   }
 }
 
-class SequenceDelimitationPartMarker(override val bigEndian: Boolean) extends SequenceDelimitationPart(bigEndian, emptyBytes)
+class SequenceDelimitationPartMarker(override val bigEndian: Boolean)
+    extends SequenceDelimitationPart(bigEndian, emptyBytes)
 
 class ItemDelimitationPartMarker(override val bigEndian: Boolean) extends ItemDelimitationPart(bigEndian, emptyBytes)
 
@@ -269,7 +270,7 @@ trait GuaranteedDelimitationEvents[Out] extends DicomFlow[Out] with InFragments[
       partStack = active // only keep items and sequences with bytes left to subtract
       inactive.flatMap { // call events, any items will be inserted in stream
         case (p: ItemPart, _) => onItemDelimitation(new ItemDelimitationPartMarker(p.bigEndian))
-        case (p, _)                => onSequenceDelimitation(new SequenceDelimitationPartMarker(p.bigEndian))
+        case (p, _)           => onSequenceDelimitation(new SequenceDelimitationPartMarker(p.bigEndian))
       }
     }
 
@@ -293,7 +294,8 @@ trait GuaranteedDelimitationEvents[Out] extends DicomFlow[Out] with InFragments[
         partStack = partStack.tail
       subtractAndEmit(
         part,
-        (p: SequenceDelimitationPart) => super.onSequenceDelimitation(p).filterNot(_.isInstanceOf[SequenceDelimitationPartMarker])
+        (p: SequenceDelimitationPart) =>
+          super.onSequenceDelimitation(p).filterNot(_.isInstanceOf[SequenceDelimitationPartMarker])
       )
     }
 


### PR DESCRIPTION
…nd no data) led to inserted sequence and item delimitations of the wrong endianess in big endian datasets.